### PR TITLE
Fix undefined package_name error

### DIFF
--- a/lib/release_tagger/repo.rb
+++ b/lib/release_tagger/repo.rb
@@ -40,7 +40,8 @@ Consider setting your packagecloud api token in any of:
       req.basic_auth pc_api_token, ''
       response = Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') {|http| http.request(req)}
       unless response.is_a?(Net::HTTPOK)
-        puts "Error trying to get latest version of package #{package_name}"
+        puts "Error trying to get latest version of package"
+        puts "URL: #{url}"
         puts response.code
         exit 1
       end


### PR DESCRIPTION
At the moment, if the request to PackageCloud fails, the tool crashes
out, as it tries to print an error containing the `package_name`
variable, which is never defined anywhere. This updates the failure
state to print the URL instead, which is more useful for debugging.